### PR TITLE
Remove tabs for recent `purs` compatibility

### DIFF
--- a/src/Data/VectorField.purs
+++ b/src/Data/VectorField.purs
@@ -5,12 +5,12 @@ import Data.Group (class Group)
 import Data.Semigroup.Commutative (class Commutative)
 
 class (Field k, Group (f k), Commutative (f k)) <= VectorField f k where
-	-- | - ∀v in V: one * v == v 
-	-- | - ∀a b in K, v in V: a * (b .* v) = (a * b) .* v
-	-- | - ∀a b in K, v in V: 
-	-- | 		- a .* (u + v) = a .* u + a .* v 
-	-- |  	- (a + b) .* v = a .* v + b .* v
-	scalarMul :: k -> f k -> f k
+    -- | - ∀v in V: one * v == v 
+    -- | - ∀a b in K, v in V: a * (b .* v) = (a * b) .* v
+    -- | - ∀a b in K, v in V: 
+    -- |      - a .* (u + v) = a .* u + a .* v 
+    -- |      - (a + b) .* v = a .* v + b .* v
+    scalarMul :: k -> f k -> f k
 
 flipScalarMul :: ∀f k. (VectorField f k) => f k -> k -> f k
 flipScalarMul = flip scalarMul


### PR DESCRIPTION
Before change:
```
$ pulp --version
Pulp version 13.0.0

$ purs --version
0.13.4

$ bower install
[...]

$ pulp build
[...]
Error found:
at src/Data/VectorField.purs:8:1 - 8:2 (line 8, column 1 - line 8, column 2)

  Unable to parse module:
  Illegal whitespace character U+0009

```

After change:
```
$ pulp build
[...]
* Build successful.
```